### PR TITLE
#16 sensor communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ hello/hello
 
 # Ignore the .DS_Store file created on Macs.
 .DS_Store
+
+# Ignore .idea folders
+.idea/

--- a/SensorCommunication/CallBackTimer.h
+++ b/SensorCommunication/CallBackTimer.h
@@ -28,7 +28,7 @@ public:
             _thd.join();
     }
 
-    void start(int interval, std::function<void(void)> func)
+    void start(unsigned long int interval, std::function<void(void)> func)
     {
         if( _execute.load(std::memory_order_acquire) ) {
             stop();

--- a/SensorCommunication/CallBackTimer.h
+++ b/SensorCommunication/CallBackTimer.h
@@ -1,0 +1,57 @@
+//
+// Created by pbrink on 25/03/18.
+//
+
+#ifndef SENSOR_COMMUNICATION_CALLBACKTIMER_H
+#define SENSOR_COMMUNICATION_CALLBACKTIMER_H
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <thread>
+
+class CallBackTimer
+{
+public:
+    CallBackTimer() :_execute(false) {}
+
+    ~CallBackTimer() {
+        if( _execute.load(std::memory_order_acquire) ) {
+            stop();
+        };
+    }
+
+    void stop()
+    {
+        _execute.store(false, std::memory_order_release);
+        if( _thd.joinable() )
+            _thd.join();
+    }
+
+    void start(int interval, std::function<void(void)> func)
+    {
+        if( _execute.load(std::memory_order_acquire) ) {
+            stop();
+        };
+        _execute.store(true, std::memory_order_release);
+        _thd = std::thread([this, interval, func]()
+                           {
+                               while (_execute.load(std::memory_order_acquire)) {
+                                   func();
+                                   std::this_thread::sleep_for(
+                                           std::chrono::milliseconds(interval));
+                               }
+                           });
+    }
+
+    bool is_running() const noexcept {
+        return ( _execute.load(std::memory_order_acquire) &&
+                 _thd.joinable() );
+    }
+
+private:
+    std::atomic<bool> _execute;
+    std::thread _thd;
+};
+
+#endif //SENSOR_COMMUNICATION_CALLBACKTIMER_H

--- a/SensorCommunication/SampleSensor.cpp
+++ b/SensorCommunication/SampleSensor.cpp
@@ -9,15 +9,11 @@ SampleSensor::SampleSensor(string name, string address, unsigned long samplingFr
                                                                                  action, inputFileName,
                                                                                  outputFileName) {}
 
-string SampleSensor::read() {
-    std::cout << "Enter an input: ";
-    string input;
-    std::cin >> input;
-    return input;
+void SampleSensor::readFrom() {
+    string input = receiveFromInput();
+    writeTo(input);
 }
 
-bool SampleSensor::write(string toWrite) {
-    std::cout << toWrite;
-    // for validation purposes
-    return true;
+void SampleSensor::writeTo(string toWrite) {
+    sendToOutput(toWrite);
 }

--- a/SensorCommunication/SampleSensor.cpp
+++ b/SensorCommunication/SampleSensor.cpp
@@ -1,0 +1,23 @@
+#include <iostream>
+#include "SampleSensor.h"
+
+//
+// Created by pbrink on 26/03/18.
+//
+SampleSensor::SampleSensor(string name, string address, unsigned long samplingFrequency, ReadWrite action,
+                           string inputFileName, string outputFileName) : Sensor(name, address, samplingFrequency,
+                                                                                 action, inputFileName,
+                                                                                 outputFileName) {}
+
+string SampleSensor::read() {
+    std::cout << "Enter an input: ";
+    string input;
+    std::cin >> input;
+    return input;
+}
+
+bool SampleSensor::write(string toWrite) {
+    std::cout << toWrite;
+    // for validation purposes
+    return true;
+}

--- a/SensorCommunication/SampleSensor.h
+++ b/SensorCommunication/SampleSensor.h
@@ -14,8 +14,8 @@ public:
                  string inputFileName, string outputFileName);
     ~SampleSensor() override {};
 private:
-    string read() override;
-    bool write(string toWrite) override;
+    void readFrom() override;
+    void writeTo(string toWrite) override;
 };
 
 

--- a/SensorCommunication/SampleSensor.h
+++ b/SensorCommunication/SampleSensor.h
@@ -1,0 +1,22 @@
+//
+// Created by pbrink on 26/03/18.
+//
+
+#ifndef SPACECRAFTSOFTWARE_SAMPLESENSOR_H
+#define SPACECRAFTSOFTWARE_SAMPLESENSOR_H
+
+
+#include "Sensor.h"
+
+class SampleSensor: public Sensor {
+public:
+    SampleSensor(string name, string address, unsigned long samplingFrequency, ReadWrite action,
+                 string inputFileName, string outputFileName);
+    ~SampleSensor() override {};
+private:
+    string read() override;
+    bool write(string toWrite) override;
+};
+
+
+#endif //SPACECRAFTSOFTWARE_SAMPLESENSOR_H

--- a/SensorCommunication/Sensor.cpp
+++ b/SensorCommunication/Sensor.cpp
@@ -17,7 +17,7 @@ Sensor::Sensor(string name,
         if (isFilenameAllowed(outputFileName)) {
             this->outputFileName = outputFileName;
         } else {
-            throw new 
+            throw new std::exception
         }
     }
 }

--- a/SensorCommunication/Sensor.cpp
+++ b/SensorCommunication/Sensor.cpp
@@ -4,6 +4,10 @@
 
 #include <stdexcept>
 #include <iostream>
+#include <cstring>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 #include "Sensor.h"
 
 Sensor::Sensor(string name,
@@ -18,15 +22,21 @@ Sensor::Sensor(string name,
     if (action == ReadWrite::READ || action == ReadWrite::READ_WRITE) {
         if (isFilenameAllowed(outputFileName)) {
             this->outputFileName = outputFileName;
+            if (!createNamedPipe(outputFileName, true)) {
+                throw std::invalid_argument("Invalid output filename provided");
+            }
         } else {
-            throw std::invalid_argument("Invalid filename provided");
+            throw std::invalid_argument("Invalid output filename provided");
         }
     }
     if (action == ReadWrite::WRITE || action == ReadWrite::READ_WRITE) {
         if (isFilenameAllowed(inputFileName)) {
             this->inputFileName = inputFileName;
+            if (!createNamedPipe(inputFileName, false)) {
+                throw std::invalid_argument("Invalid input filename provided");
+            }
         } else {
-            throw std::invalid_argument("Invalid filename provided");
+            throw std::invalid_argument("Invalid input filename provided");
         }
     }
 
@@ -58,7 +68,7 @@ bool Sensor::startReading() {
     if (currentlyRunning) {
         return true;
     } else {
-        timer->start(samplingFrequency, std::bind(&Sensor::read, this));
+        timer->start(samplingFrequency, std::bind(&Sensor::readFrom, this));
         currentlyRunning = true;
     }
     return false;
@@ -76,14 +86,84 @@ bool Sensor::stopReading() {
 
 Sensor::~Sensor() {
     delete timer;
+    if (fifoInput != 0) {
+        close(fifoInput);
+        if (createdFifoInput) {
+            // delete the named pipe we made
+            unlink(inputFileName.c_str());
+        }
+    }
+    if (fifoOutput != 0) {
+        close(fifoOutput);
+        if (createdFifoOutput) {
+            // delete the named pipe we made
+            unlink(outputFileName.c_str());
+        }
+    }
 }
 
-bool Sensor::sendToOutputFile(string output) {
-    // TODO: Switch to named pipes
-    std::cout << output + " ";
+void Sensor::sendToOutput(string output) {
+    // convert output to c_string
+    const char* out = output.c_str();
+    // open pipe
+    ssize_t status;
+    fifoOutput = open(outputFileName.c_str(), O_WRONLY);
+    if (fifoOutput < 0) {
+        printf("\n %s \n", strerror(errno));
+    }
+    // write to the pipe
+    status = write(fifoOutput, out, strlen(out));
+    if (status < 0) {
+        printf("\n %s \n", strerror(errno));
+    }
 }
 
 string Sensor::receiveFromInput() {
-    // TODO: Switch to named pipes
-    return ".";
+    // open pipe
+    fifoInput = open(inputFileName.c_str(), O_RDONLY);
+    if (fifoInput < 0) {
+        printf("\n %s \n", strerror(errno));
+    }
+    // read from the pipe
+
+    ssize_t status;
+    status = read(fifoInput, readingFifoBuffer, 512);
+    // TODO: for some reason this is returning 7 even though it is working properly. Figure out why
+//    if (status != 0) {
+//        printf("\n %s \n", strerror(errno));
+//    }
+
+    // look for \0 bytes (termination of c strings)
+    // TODO: ensure that non c strings will not result in endless loops
+    int index = 0;
+    char result[512];
+    while (readingFifoBuffer[index] != '\0') {
+        result[index] = readingFifoBuffer[index];
+        index++;
+    }
+    result[index] = '\0';
+    return std::string(result);
+}
+
+bool Sensor::createNamedPipe(string filename, bool forWriting) {
+    struct stat buffer;
+    if (stat (filename.c_str(), &buffer) == 0) {
+        // the file exists, check if it is a named pipe
+        if (S_ISFIFO(buffer.st_mode)) {
+            return true;
+        } else {
+            // the file already exists, but it is not a named pipe
+            return false;
+        }
+    } else {
+        // create the file
+        int status;
+        status = mkfifo(filename.c_str(), 0644);
+        if (status != 0) {
+            return false;
+        } else {
+            forWriting ? (createdFifoOutput = true) : (createdFifoInput = true);
+            return true;
+        }
+    }
 }

--- a/SensorCommunication/Sensor.cpp
+++ b/SensorCommunication/Sensor.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <stdexcept>
+#include <iostream>
 #include "Sensor.h"
 
 Sensor::Sensor(string name,
@@ -30,11 +31,14 @@ Sensor::Sensor(string name,
     }
 
     // validate sampling frequency
-    if (samplingFrequency <= SAMPLING_FREQUENCY_LOWER_LIMIT || samplingFrequency > SAMPLING_FREQUENCY_UPPER_LIMIT) {
+    if (samplingFrequency < SAMPLING_FREQUENCY_LOWER_LIMIT || samplingFrequency > SAMPLING_FREQUENCY_UPPER_LIMIT) {
         throw std::invalid_argument("Invalid sampling frequency provided");
     } else {
         this->samplingFrequency = samplingFrequency;
     }
+
+    // create the callback timer
+    timer = new CallBackTimer();
 }
 
 bool Sensor::isFilenameAllowed(string filename) {
@@ -42,25 +46,44 @@ bool Sensor::isFilenameAllowed(string filename) {
     return true;
 }
 
-bool Sensor::setSamplingFrequency() {
-    return false;
+bool Sensor::setSamplingFrequency(unsigned long int samplingFrequency) {
+    if (samplingFrequency < SAMPLING_FREQUENCY_LOWER_LIMIT || samplingFrequency > SAMPLING_FREQUENCY_UPPER_LIMIT) {
+        return false;
+    } else {
+        this->samplingFrequency = samplingFrequency;
+    }
 }
 
-bool Sensor::start() {
+bool Sensor::startReading() {
     if (currentlyRunning) {
         return true;
     } else {
-        read();
+        timer->start(samplingFrequency, std::bind(&Sensor::read, this));
         currentlyRunning = true;
     }
     return false;
 }
 
-bool Sensor::stop() {
+bool Sensor::stopReading() {
     if (!currentlyRunning) {
         return true;
     } else {
+        timer->stop();
         currentlyRunning = false;
     }
     return false;
+}
+
+Sensor::~Sensor() {
+    delete timer;
+}
+
+bool Sensor::sendToOutputFile(string output) {
+    // TODO: Switch to named pipes
+    std::cout << output + " ";
+}
+
+string Sensor::receiveFromInput() {
+    // TODO: Switch to named pipes
+    return ".";
 }

--- a/SensorCommunication/Sensor.cpp
+++ b/SensorCommunication/Sensor.cpp
@@ -2,27 +2,65 @@
 // Created by pbrink on 22/03/18.
 //
 
+#include <stdexcept>
 #include "Sensor.h"
 
 Sensor::Sensor(string name,
                string address,
-               float samplingFrequency,
+               unsigned long int samplingFrequency,
                ReadWrite action,
                string inputFileName,
                string outputFileName) :
-                name(name), address(address), samplingFrequency(samplingFrequency), action(action)
+                name(name), address(address), action(action)
 {
     // ensure that input and output filenames are properly specified when necessary
     if (action == ReadWrite::READ || action == ReadWrite::READ_WRITE) {
         if (isFilenameAllowed(outputFileName)) {
             this->outputFileName = outputFileName;
         } else {
-            throw new std::exception
+            throw std::invalid_argument("Invalid filename provided");
         }
+    }
+    if (action == ReadWrite::WRITE || action == ReadWrite::READ_WRITE) {
+        if (isFilenameAllowed(inputFileName)) {
+            this->inputFileName = inputFileName;
+        } else {
+            throw std::invalid_argument("Invalid filename provided");
+        }
+    }
+
+    // validate sampling frequency
+    if (samplingFrequency <= SAMPLING_FREQUENCY_LOWER_LIMIT || samplingFrequency > SAMPLING_FREQUENCY_UPPER_LIMIT) {
+        throw std::invalid_argument("Invalid sampling frequency provided");
+    } else {
+        this->samplingFrequency = samplingFrequency;
     }
 }
 
 bool Sensor::isFilenameAllowed(string filename) {
     // TODO: verification of good filenames and paths
     return true;
+}
+
+bool Sensor::setSamplingFrequency() {
+    return false;
+}
+
+bool Sensor::start() {
+    if (currentlyRunning) {
+        return true;
+    } else {
+        read();
+        currentlyRunning = true;
+    }
+    return false;
+}
+
+bool Sensor::stop() {
+    if (!currentlyRunning) {
+        return true;
+    } else {
+        currentlyRunning = false;
+    }
+    return false;
 }

--- a/SensorCommunication/Sensor.cpp
+++ b/SensorCommunication/Sensor.cpp
@@ -1,0 +1,28 @@
+//
+// Created by pbrink on 22/03/18.
+//
+
+#include "Sensor.h"
+
+Sensor::Sensor(string name,
+               string address,
+               float samplingFrequency,
+               ReadWrite action,
+               string inputFileName,
+               string outputFileName) :
+                name(name), address(address), samplingFrequency(samplingFrequency), action(action)
+{
+    // ensure that input and output filenames are properly specified when necessary
+    if (action == ReadWrite::READ || action == ReadWrite::READ_WRITE) {
+        if (isFilenameAllowed(outputFileName)) {
+            this->outputFileName = outputFileName;
+        } else {
+            throw new 
+        }
+    }
+}
+
+bool Sensor::isFilenameAllowed(string filename) {
+    // TODO: verification of good filenames and paths
+    return true;
+}

--- a/SensorCommunication/Sensor.h
+++ b/SensorCommunication/Sensor.h
@@ -26,6 +26,7 @@ public:
            ReadWrite action,
            string inputFileName,
            string outputFileName);
+    virtual ~Sensor();
     string getInputFilename() { return inputFileName; }
     string getOutputFilename() { return outputFileName; }
     unsigned long int getSamplingFrequency() { return samplingFrequency; }
@@ -36,13 +37,12 @@ public:
     bool isCurrentlyRunning() { return currentlyRunning; }
     bool startReading();
     bool stopReading();
-    virtual ~Sensor();
-protected:
-    bool sendToOutputFile(string output);
     string receiveFromInput();
+    virtual void writeTo(string toWrite) = 0;
+protected:
+    virtual void readFrom()= 0;
+    void sendToOutput(string output);
 private:
-    virtual string read()= 0;
-    virtual bool write(string toWrite) = 0;
     string name;
     string address;
     unsigned long int samplingFrequency;
@@ -51,7 +51,13 @@ private:
     string outputFileName;
     bool currentlyRunning;
     CallBackTimer* timer;
+    int fifoInput;
+    int fifoOutput;
+    bool createdFifoInput;
+    bool createdFifoOutput;
+    char readingFifoBuffer[512];
     bool isFilenameAllowed(string filename);
+    bool createNamedPipe(string filename, bool forWriting);
 };
 
 #endif //SPACECRAFTSOFTWARE_SENSORS_H

--- a/SensorCommunication/Sensor.h
+++ b/SensorCommunication/Sensor.h
@@ -9,19 +9,30 @@
 
 using std::string
 
+enum class ReadWrite {
+    READ,
+    WRITE,
+    READ_WRITE
+};
+
 class Sensor {
 public:
+    unsigned long SAMPLING_FREQUENCY_LOWER_LIMIT = 1; // 1 millisecond TODO: Determine a lower limit
+    unsigned long SAMPLING_FREQUENCY_UPPER_LIMIT = 864000000; // 10 days TODO: Determine an upper limit
     Sensor(string name,
            string address,
-           float samplingFrequency,
+           unsigned long int samplingFrequency,
            ReadWrite action,
            string inputFileName,
            string outputFileName);
     string getInputFilename() { return inputFileName; }
     string getOutputFilename() { return outputFileName; }
-    float getSamplingFrequency() { return samplingFrequency; }
+    unsigned long int getSamplingFrequency() { return samplingFrequency; }
     bool setSamplingFrequency();
     string getName() { return name; }
+    string getAddress() { return address; }
+    ReadWrite getAction() { return action; }
+    bool isCurrentlyRunning() { return currentlyRunning}
     bool start();
     bool stop();
     virtual ~Sensor() = 0;
@@ -30,18 +41,12 @@ private:
     virtual string write() = 0;
     string name;
     string address;
-    float samplingFrequency;
+    unsigned long int samplingFrequency;
     ReadWrite action;
     string inputFileName;
     string outputFileName;
-
+    bool currentlyRunning;
     bool isFilenameAllowed(string filename);
-};
-
-enum class ReadWrite {
-    READ,
-    WRITE,
-    READ_WRITE
 };
 
 #endif //SPACECRAFTSOFTWARE_SENSORS_H

--- a/SensorCommunication/Sensor.h
+++ b/SensorCommunication/Sensor.h
@@ -6,8 +6,9 @@
 #define SPACECRAFTSOFTWARE_SENSORS_H
 
 #include <string>
+#include "CallBackTimer.h"
 
-using std::string
+using std::string;
 
 enum class ReadWrite {
     READ,
@@ -28,17 +29,20 @@ public:
     string getInputFilename() { return inputFileName; }
     string getOutputFilename() { return outputFileName; }
     unsigned long int getSamplingFrequency() { return samplingFrequency; }
-    bool setSamplingFrequency();
+    bool setSamplingFrequency(unsigned long int samplingFrequency);
     string getName() { return name; }
     string getAddress() { return address; }
     ReadWrite getAction() { return action; }
-    bool isCurrentlyRunning() { return currentlyRunning}
-    bool start();
-    bool stop();
-    virtual ~Sensor() = 0;
+    bool isCurrentlyRunning() { return currentlyRunning; }
+    bool startReading();
+    bool stopReading();
+    virtual ~Sensor();
+protected:
+    bool sendToOutputFile(string output);
+    string receiveFromInput();
 private:
     virtual string read()= 0;
-    virtual string write() = 0;
+    virtual bool write(string toWrite) = 0;
     string name;
     string address;
     unsigned long int samplingFrequency;
@@ -46,6 +50,7 @@ private:
     string inputFileName;
     string outputFileName;
     bool currentlyRunning;
+    CallBackTimer* timer;
     bool isFilenameAllowed(string filename);
 };
 

--- a/SensorCommunication/Sensor.h
+++ b/SensorCommunication/Sensor.h
@@ -1,0 +1,47 @@
+//
+// Created by pbrink on 22/03/18.
+//
+
+#ifndef SPACECRAFTSOFTWARE_SENSORS_H
+#define SPACECRAFTSOFTWARE_SENSORS_H
+
+#include <string>
+
+using std::string
+
+class Sensor {
+public:
+    Sensor(string name,
+           string address,
+           float samplingFrequency,
+           ReadWrite action,
+           string inputFileName,
+           string outputFileName);
+    string getInputFilename() { return inputFileName; }
+    string getOutputFilename() { return outputFileName; }
+    float getSamplingFrequency() { return samplingFrequency; }
+    bool setSamplingFrequency();
+    string getName() { return name; }
+    bool start();
+    bool stop();
+    virtual ~Sensor() = 0;
+private:
+    virtual string read()= 0;
+    virtual string write() = 0;
+    string name;
+    string address;
+    float samplingFrequency;
+    ReadWrite action;
+    string inputFileName;
+    string outputFileName;
+
+    bool isFilenameAllowed(string filename);
+};
+
+enum class ReadWrite {
+    READ,
+    WRITE,
+    READ_WRITE
+};
+
+#endif //SPACECRAFTSOFTWARE_SENSORS_H


### PR DESCRIPTION
Added the sensor comms base class and an example sensor implementing the readFrom() and writeTo() methods that must be implemented by the sensor subclasses.

Currently it is NOT included in the build system. This is because we are moving over to a new build method in the bazel branch added by Mark, or if that does not work we will move to cmake.